### PR TITLE
Bump PHP version to > 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: [ '8.0', '8.1' ]
+                php-versions: [ '8.1', '8.2', '8.3' ]
 
         name: PHP ${{ matrix.php-versions }}
 
@@ -25,9 +25,10 @@ jobs:
               run: composer install --no-ansi --no-interaction --no-scripts --no-suggest --no-progress
 
             - name: Execute tests (Unit and Feature tests) via PHPUnit
-              run: |
-                  composer test
+              run: composer test:no-coverage
 
             - name: Execute static analysis
-              run: |
-                  composer analyse
+              run: composer analyse
+
+            - name: Execute coding standards check
+              run: composer lint:check

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ composer.lock
 /.idea/
 /build/
 .phpunit.result.cache
+.phpunit.cache/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Time
 
 This package aims to make working with times (as in date, ranges and/or duration) easier. It contains a time 
-value-object, ranges, duration, rounding, etc.
+value-object, parser, ranges, duration, rounding, etc.
 
 ## Requirements
 
-This package requires PHP 8.0 or higher.
+This package requires PHP 8.1 or higher.
 
 ## Installation
 
@@ -24,6 +24,18 @@ The `Time` object can be initiated with:
 
 ```php
 $time = new Time(14, 30, 15);
+```
+
+#### Building from input
+
+To build the `Time` object from several different inputs, you can use the following methods:
+
+```php
+TimeFactory::createFromString('14:30:15'); // Time object with 14 hours, 30 minutes and 15 seconds
+TimeFactory::createFromDateTime(new \DateTime('2023-01-01 14:30:15')); // Time object with 14 hours, 30 minutes and 15 seconds
+TimeFactory::createFromTimestamp(1640000000); // Time object with 11 hours, 33 minutes and 20 seconds
+TimeFactory::createFromDurationInSeconds(9000); // Time object with 2 hours and 30 minutes
+TimeFactory::createFromDurationInMinutes(150); // Time object with 2 hours and 30 minutes
 ```
 
 #### Comparison
@@ -167,8 +179,8 @@ When you want a code coverage report which will be generated in the build/report
 
 ## Contribution
 
-Any contribution is welcome, but it should meet the PSR-12 standard and please create one pull request per feature/bug. 
-In exchange, you will be credited as contributor on this page.
+Any contribution is welcome, but it should meet the [PER 2.0 code style](https://www.php-fig.org/per/coding-style/) and 
+please create one pull request per feature/bug. In exchange, you will be credited as contributor.
 
 ## Security
 
@@ -178,8 +190,3 @@ instead of using the issue tracker.
 ## License
 
 This package is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
-
-## About vdhicts
-
-[Vdhicts](https://www.vdhicts.nl) is the name of my personal company. Vdhicts develops and implements IT solutions for
-businesses and educational institutions.

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "php": "^8.1"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9.0",
+        "phpstan/phpstan": "^1.11",
+        "phpunit/phpunit": "^10.5",
         "rector/rector": "^1.2",
         "symplify/easy-coding-standard": "^12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "vdhicts/time",
-    "description": "Time value-object, collection and a range helper useful when working with times",
+    "description": "Time value-object with parser and collection and helpers for duration, rounding and ranges. Makes working with times easy.",
     "homepage": "https://github.com/vdhicts/time",
     "license": "MIT",
     "authors": [
@@ -22,16 +22,27 @@
         }
     },
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0",
+        "rector/rector": "^1.2",
+        "symplify/easy-coding-standard": "^12.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit --no-coverage",
-        "test-coverage": "vendor/bin/phpunit",
-        "analyse": "vendor/bin/phpstan analyse"
+        "test": [
+            "@analyze",
+            "@test:no-coverage",
+            "@lint:check"
+        ],
+        "test:coverage": "vendor/bin/phpunit",
+        "test:no-coverage": "vendor/bin/phpunit --no-coverage",
+        "analyse": "vendor/bin/phpstan analyse",
+        "lint:check": "vendor/bin/ecs",
+        "lint:fix": "vendor/bin/ecs --fix",
+        "rector:check": "@rector:fix --dry-run",
+        "rector:fix": "@php vendor/bin/rector process"
     },
     "config": {
         "sort-packages": true

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\Basic\SingleLineEmptyBodyFixer;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSkip([
+        SingleLineEmptyBodyFixer::class,
+    ])
+    ->withPhpCsFixerSets(perCS20: true);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        bootstrap="vendor/autoload.php"
-        backupGlobals="false"
-        backupStaticAttributes="false"
-        colors="true"
-        verbose="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        processIsolation="false"
-        stopOnFailure="false"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="build/coverage"/>
     </report>
@@ -26,4 +11,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets(php81: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        privatization: true,
+        naming: true,
+        instanceOf: true,
+        earlyReturn: true,
+        strictBooleans: true,
+        carbon: true
+    )
+    ->withImportNames();

--- a/src/Exceptions/TimeException.php
+++ b/src/Exceptions/TimeException.php
@@ -9,21 +9,21 @@ class TimeException extends Exception
     public static function unableToCreateFromString(string $value): self
     {
         return new self(
-            sprintf('Unable to create a Time value object from `%s`', $value)
+            sprintf('Unable to create a Time value object from `%s`', $value),
         );
     }
 
     public static function invalidMinutes(int $minutes): self
     {
         return new self(
-            sprintf('Invalid minutes provided: `%d`, must be between 0 and 59', $minutes)
+            sprintf('Invalid minutes provided: `%d`, must be between 0 and 59', $minutes),
         );
     }
 
     public static function invalidSeconds(int $seconds): self
     {
         return new self(
-            sprintf('Invalid seconds provided: `%d`, must be between 0 and 59', $seconds)
+            sprintf('Invalid seconds provided: `%d`, must be between 0 and 59', $seconds),
         );
     }
 

--- a/src/TimeCollection.php
+++ b/src/TimeCollection.php
@@ -2,24 +2,25 @@
 
 namespace Vdhicts\Time;
 
-use Vdhicts\Time\Contracts;
+use Vdhicts\Time\Contracts\TimeCollectionInterface;
+use Vdhicts\Time\Contracts\TimeInterface;
 
-class TimeCollection implements Contracts\TimeCollectionInterface
+class TimeCollection implements TimeCollectionInterface
 {
     /**
-     * @var Contracts\TimeInterface[]
+     * @var TimeInterface[]
      */
     private array $times = [];
 
     /**
-     * @param Contracts\TimeInterface[] $times
+     * @param TimeInterface[] $times
      */
     public function __construct(array $times = [])
     {
         $this->set($times);
     }
 
-    public function add(Contracts\TimeInterface $time): Contracts\TimeCollectionInterface
+    public function add(TimeInterface $time): TimeCollectionInterface
     {
         $this->times[] = $time;
 
@@ -29,7 +30,7 @@ class TimeCollection implements Contracts\TimeCollectionInterface
     /*
      * @inheritDoc
      */
-    public function set(array $times): Contracts\TimeCollectionInterface
+    public function set(array $times): TimeCollectionInterface
     {
         $this->times = [];
 
@@ -40,15 +41,13 @@ class TimeCollection implements Contracts\TimeCollectionInterface
         return $this;
     }
 
-    public function contains(Contracts\TimeInterface $time): bool
+    public function contains(TimeInterface $time): bool
     {
         $times = array_map(
-            function (Contracts\TimeInterface $time) {
-                return $time->toString();
-            },
-            $this->times
+            fn(TimeInterface $time): string => $time->toString(),
+            $this->times,
         );
 
-        return in_array($time->toString(), $times);
+        return in_array($time->toString(), $times, true);
     }
 }

--- a/src/TimeFactory.php
+++ b/src/TimeFactory.php
@@ -12,7 +12,7 @@ class TimeFactory
     public static function createFromString(string $value): Time
     {
         $timestamp = strtotime($value);
-        if (! $timestamp) {
+        if ($timestamp === 0 || $timestamp === false) {
             throw TimeException::unableToCreateFromString($value);
         }
 
@@ -29,9 +29,9 @@ class TimeFactory
         $seconds = date('s', $timestamp);
 
         return (new Time())
-            ->setHours((int)$hours)
-            ->setMinutes((int)$minutes)
-            ->setSeconds((int)$seconds);
+            ->setHours((int) $hours)
+            ->setMinutes((int) $minutes)
+            ->setSeconds((int) $seconds);
     }
 
     /**
@@ -41,9 +41,9 @@ class TimeFactory
     {
         $hours = floor($seconds / 3600);
         $minutes = floor($seconds / 60) % 60;
-        $seconds = $seconds % 60;
+        $seconds %= 60;
 
-        return new Time((int)$hours, $minutes, $seconds);
+        return new Time((int) $hours, $minutes, $seconds);
     }
 
     /**
@@ -52,8 +52,8 @@ class TimeFactory
     public static function createFromDurationInMinutes(int $minutes): Time
     {
         $hours = floor($minutes / 60);
-        $minutes = $minutes % 60;
+        $minutes %= 60;
 
-        return new Time((int)$hours, $minutes, 0);
+        return new Time((int) $hours, $minutes, 0);
     }
 }

--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -2,25 +2,23 @@
 
 namespace Vdhicts\Time;
 
-use Vdhicts\Time\Contracts;
+use Vdhicts\Time\Contracts\TimeInterface;
+use Vdhicts\Time\Contracts\TimeRangeInterface;
 
-class TimeRange implements Contracts\TimeRangeInterface
+class TimeRange implements TimeRangeInterface
 {
-    private Contracts\TimeInterface $start;
-    private Contracts\TimeInterface $end;
-
-    public function __construct(Contracts\TimeInterface $start, Contracts\TimeInterface $end)
-    {
-        $this->start = $start;
-        $this->end = $end;
+    public function __construct(
+        private readonly TimeInterface $start,
+        private readonly TimeInterface $end,
+    ) {
     }
 
-    public function getStart(): Contracts\TimeInterface
+    public function getStart(): TimeInterface
     {
         return $this->start;
     }
 
-    public function getEnd(): Contracts\TimeInterface
+    public function getEnd(): TimeInterface
     {
         return $this->end;
     }
@@ -28,7 +26,7 @@ class TimeRange implements Contracts\TimeRangeInterface
     /**
      * Determines if the time is in between or equals to the start and end of this time range.
      */
-    public function inRange(Contracts\TimeInterface $time): bool
+    public function inRange(TimeInterface $time): bool
     {
         $startIsAfterOrEqualTo = $time->isAfterOrEqualTo($this->start);
         $endIsBeforeOrEqualTo = $time->isBeforeOrEqualTo($this->end);
@@ -39,7 +37,7 @@ class TimeRange implements Contracts\TimeRangeInterface
     /**
      * Determine if the time ranges are overlapping each other.
      */
-    public function isOverlapping(Contracts\TimeRangeInterface $timeRange): bool
+    public function isOverlapping(TimeRangeInterface $timeRange): bool
     {
         $startIsBeforeOrEqualToEnd = $this
             ->getStart()
@@ -54,7 +52,7 @@ class TimeRange implements Contracts\TimeRangeInterface
     /**
      * Returns the time object for the duration of the range.
      */
-    public function getRangeDuration(): Contracts\TimeInterface
+    public function getRangeDuration(): TimeInterface
     {
         return $this
             ->start

--- a/src/Traits/Comparison.php
+++ b/src/Traits/Comparison.php
@@ -18,7 +18,11 @@ trait Comparison
 
     public function isBeforeOrEqualTo(TimeInterface $time): bool
     {
-        return $this->isEqualTo($time) || $this->isBefore($time);
+        if ($this->isEqualTo($time)) {
+            return true;
+        }
+
+        return $this->isBefore($time);
     }
 
     public function isAfter(TimeInterface $time): bool
@@ -28,6 +32,10 @@ trait Comparison
 
     public function isAfterOrEqualTo(TimeInterface $time): bool
     {
-        return $this->isEqualTo($time) || $this->isAfter($time);
+        if ($this->isEqualTo($time)) {
+            return true;
+        }
+
+        return $this->isAfter($time);
     }
 }

--- a/src/Traits/Rounding.php
+++ b/src/Traits/Rounding.php
@@ -17,14 +17,14 @@ trait Rounding
 
         return match ($method) {
             'up' => $roundSeconds
-                ? TimeFactory::createFromDurationInSeconds((int)ceil($seconds / $precision) * $precision)
-                : TimeFactory::createFromDurationInSeconds((int)ceil($seconds / ($precision * 60)) * ($precision * 60)),
+                ? TimeFactory::createFromDurationInSeconds((int) ceil($seconds / $precision) * $precision)
+                : TimeFactory::createFromDurationInSeconds((int) ceil($seconds / ($precision * 60)) * ($precision * 60)),
             'down' => $roundSeconds
-                ? TimeFactory::createFromDurationInSeconds((int)floor($seconds / $precision) * $precision)
-                : TimeFactory::createFromDurationInSeconds((int)floor($seconds / ($precision * 60)) * ($precision * 60)),
+                ? TimeFactory::createFromDurationInSeconds((int) floor($seconds / $precision) * $precision)
+                : TimeFactory::createFromDurationInSeconds((int) floor($seconds / ($precision * 60)) * ($precision * 60)),
             default => $roundSeconds
-                ? TimeFactory::createFromDurationInSeconds((int)round($seconds / $precision) * $precision)
-                : TimeFactory::createFromDurationInSeconds((int)round($seconds / ($precision * 60)) * ($precision * 60)),
+                ? TimeFactory::createFromDurationInSeconds((int) round($seconds / $precision) * $precision)
+                : TimeFactory::createFromDurationInSeconds((int) round($seconds / ($precision * 60)) * ($precision * 60)),
         };
     }
 

--- a/tests/Unit/TimeCollectionTest.php
+++ b/tests/Unit/TimeCollectionTest.php
@@ -37,10 +37,10 @@ class TimeCollectionTest extends TestCase
 
         $times = [$time, $anotherTime];
 
-        $collection = new TimeCollection($times);
+        $timeCollection = new TimeCollection($times);
 
-        $this->assertTrue($collection->contains($time));
-        $this->assertTrue($collection->contains($anotherTime));
-        $this->assertFalse($collection->contains($specialTime));
+        $this->assertTrue($timeCollection->contains($time));
+        $this->assertTrue($timeCollection->contains($anotherTime));
+        $this->assertFalse($timeCollection->contains($specialTime));
     }
 }

--- a/tests/Unit/TimeTest.php
+++ b/tests/Unit/TimeTest.php
@@ -37,14 +37,14 @@ class TimeTest extends TestCase
     {
         $this->expectException(TimeException::class);
 
-        $time = new Time(14, 89);
+        new Time(14, 89);
     }
 
     public function testSetSecondsException(): void
     {
         $this->expectException(TimeException::class);
 
-        $time = new Time(14, 30, 89);
+        new Time(14, 30, 89);
     }
 
     public function testComparison(): void
@@ -74,7 +74,7 @@ class TimeTest extends TestCase
         $time = new Time($hours, $minutes, $seconds);
 
         $this->assertSame('14:30:15', $time->toString());
-        $this->assertSame('14:30:15', (string)$time);
+        $this->assertSame('14:30:15', (string) $time);
     }
 
     public function testClone(): void
@@ -147,8 +147,8 @@ class TimeTest extends TestCase
 
         $this->assertSame(-3.5, $timeEnd->diffInHours($timeStart));
         $this->assertSame(3.5, $timeStart->diffInHours($timeEnd));
-        $this->assertSame(-210, (int)$timeEnd->diffInMinutes($timeStart));
-        $this->assertSame(210, (int)$timeStart->diffInMinutes($timeEnd));
+        $this->assertSame(-210, (int) $timeEnd->diffInMinutes($timeStart));
+        $this->assertSame(210, (int) $timeStart->diffInMinutes($timeEnd));
         $this->assertSame(-12600, $timeEnd->diffInSeconds($timeStart));
         $this->assertSame(12600, $timeStart->diffInSeconds($timeEnd));
     }


### PR DESCRIPTION
# Changes

- Bump PHP version to 8.1 or higher as PHP 8.0 is no longer supported
- Bump PHPUnit version
- Add ECS for code style (also added to CI)
- Add rector for PHP upgrades
- Add documentation about the TimeFactory to the readme
